### PR TITLE
Updates regular expressions for additional svn-external formats

### DIFF
--- a/git-svn-ext
+++ b/git-svn-ext
@@ -151,9 +151,10 @@ def get_git_svn_externals():
         if external_dir_match:
             # the external dir is a relative dir, but starts with a slash
             # remove the leading /
-            tmp = re.sub("^/", "", external_dir_match.group(1))
-            if tmp != "":
-                external_dir = tmp
+            if external_dir_match.group(1) and external_dir_match.group(1)[0] == "/":
+                tmp = re.sub("^/", "", external_dir_match.group(1))
+                if tmp != "":
+                    external_dir = tmp
         elif line != "":
             # start array
             if not results.has_key(external_dir): results[external_dir] = []
@@ -247,7 +248,7 @@ class SvnExternal:
         dash_rev_part   = r"(-r\s*(?P<rev>\d+))?\s*"
 
         re_pre_1_5  = re.compile(r"(?P<dir>.+?)\s+%s(?P<url>%s.+)" % ( dash_rev_part, scheme_part))
-        re_1_5_plus = re.compile(r"%s(?P<url>.+?)(@(?P<rev2>\d+))?\s+(?P<dir>.+)" % (dash_rev_part))
+        re_1_5_plus = re.compile(r"/?%s'?(?P<url>.+?)(@(?P<rev2>\d+))?'?\s+(?P<dir>.+)" % (dash_rev_part))
 
         match_dict = {}
         postprocess_1_5 = False


### PR DESCRIPTION
I found some svn external formats that had '/' at the beginning of many of the lines.  This caused the external detection to go wrong.

I updated the regular expression checking to handle this as well.  The use cases I found also had single quotes around the url section, so I updated the regular expression to optionally handle the / and the single quotes.