### PR TITLE
Handle parent directories for output symlink directories

### DIFF
--- a/git-svn-ext
+++ b/git-svn-ext
@@ -424,6 +424,9 @@ class GitSvnExternal:
 
         # construct relative link
         current_dir = os.getcwd()
+        # Create parent directories (eg: foo/bar/baz) if required 
+        if not os.path.exists(os.path.dirname(self.symlink_())):
+            os.makedirs(os.path.dirname(self.symlink_()))
         os.chdir(os.path.dirname(self.symlink_()))
         rel = get_relative_base()
         os.chdir(current_dir)


### PR DESCRIPTION
I found that if the output symlink was to go inside of another directory that may not already exist, the script failed.

This change will recursively create directories for the symlink to be placed inside.